### PR TITLE
Fix for issue #4

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -999,7 +999,7 @@ function main() {
                 }
                 else {
                     appId = yield executeO365CLICommand(`spo app add -p ${appFilePath} ${overwrite}`);
-                    yield executeO365CLICommand(`spo app deploy --id ${appId} ${skipFeatureDeployment}`);
+                    yield executeO365CLICommand(`spo app deploy ${skipFeatureDeployment} --id ${appId}`);
                 }
                 core.info("✅ Upload and deployment complete.");
                 core.setOutput("APP_ID", appId);

--- a/dist/index.js
+++ b/dist/index.js
@@ -994,7 +994,7 @@ function main() {
                     }
                     else {
                         appId = yield executeO365CLICommand(`spo app add -p ${appFilePath} --scope sitecollection --appCatalogUrl ${siteCollectionUrl} ${overwrite}`);
-                        yield executeO365CLICommand(`spo app deploy --id ${appId} --scope sitecollection --appCatalogUrl ${siteCollectionUrl} ${skipFeatureDeployment}`);
+                        yield executeO365CLICommand(`spo app deploy --scope sitecollection --appCatalogUrl ${siteCollectionUrl} ${skipFeatureDeployment} --id ${appId}`);
                     }
                 }
                 else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ async function main() {
                 }
             } else {
                 appId = await executeO365CLICommand(`spo app add -p ${appFilePath} ${overwrite}`);
-                await executeO365CLICommand(`spo app deploy --id ${appId} ${skipFeatureDeployment}`);
+                await executeO365CLICommand(`spo app deploy ${skipFeatureDeployment} --id ${appId}`);
             }
             core.info("✅ Upload and deployment complete.");
             core.setOutput("APP_ID", appId);

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ async function main() {
                     core.setFailed("SITE_COLLECTION_URL not specified");
                 } else {
                     appId = await executeO365CLICommand(`spo app add -p ${appFilePath} --scope sitecollection --appCatalogUrl ${siteCollectionUrl} ${overwrite}`);
-                    await executeO365CLICommand(`spo app deploy --id ${appId} --scope sitecollection --appCatalogUrl ${siteCollectionUrl} ${skipFeatureDeployment}`);
+                    await executeO365CLICommand(`spo app deploy --scope sitecollection --appCatalogUrl ${siteCollectionUrl} ${skipFeatureDeployment} --id ${appId}`);
                 }
             } else {
                 appId = await executeO365CLICommand(`spo app add -p ${appFilePath} ${overwrite}`);


### PR DESCRIPTION
Parameters provided to the spo app deploy command have been rearranged so that the appId is added last. This means that all parameters get added to the command string regardless of whether there is a new line character included in the appId variable. 
This allows tenant wide deploy to work when run on a windows instance.